### PR TITLE
Running the package on IIS

### DIFF
--- a/src/Umbraco.Community.Sustainability/Services/SustainabilityService.cs
+++ b/src/Umbraco.Community.Sustainability/Services/SustainabilityService.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using System.Text.Json;
 using Microsoft.Playwright;
 using Umbraco.Community.Sustainability.Models;

--- a/src/Umbraco.Community.Sustainability/SustainabilityComposer.cs
+++ b/src/Umbraco.Community.Sustainability/SustainabilityComposer.cs
@@ -13,7 +13,10 @@ namespace Umbraco.Community.Sustainability
     {
         public void Compose(IUmbracoBuilder builder)
         {
-            var exitCode = Microsoft.Playwright.Program.Main(new[] { "install" });
+            string value = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            Environment.SetEnvironmentVariable("PLAYWRIGHT_BROWSERS_PATH", $"{value}\\ms-playwright");
+
+            var exitCode = Microsoft.Playwright.Program.Main(new[] { "install", "chromium" });
             if (exitCode != 0)
             {
                 throw new Exception($"Playwright exited with code {exitCode}");

--- a/src/Umbraco.Community.Sustainability/Umbraco.Community.Sustainability.csproj
+++ b/src/Umbraco.Community.Sustainability/Umbraco.Community.Sustainability.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Playwright" Version="1.40.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.43.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">


### PR DESCRIPTION
Sets an environment variable of `PLAYWRIGHT_BROWSERS_PATH` to allow the package to run correctly on IIS (see #7)