### PR TITLE
Change NodeId to NodeKey for better v14 support/migrations

### DIFF
--- a/src/Umbraco.Community.Sustainability.TestSite.13.x/Views/Home.cshtml
+++ b/src/Umbraco.Community.Sustainability.TestSite.13.x/Views/Home.cshtml
@@ -1,4 +1,4 @@
-
+﻿
 @using Umbraco.Extensions
 @using Umbraco.Cms.Web.Common.PublishedModels;
 @inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Home>

--- a/src/Umbraco.Community.Sustainability/Controllers/SustainabilityController.cs
+++ b/src/Umbraco.Community.Sustainability/Controllers/SustainabilityController.cs
@@ -1,7 +1,5 @@
-using System.Diagnostics;
 using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.CodeAnalysis.Operations;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -78,9 +76,9 @@ namespace Umbraco.Community.Sustainability.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> GetPageData([FromQuery] int pageId)
+        public async Task<IActionResult> GetPageData([FromQuery] Guid pageKey)
         {
-            var pageMetrics = await _pageMetricService.GetPageMetrics(pageId);
+            var pageMetrics = await _pageMetricService.GetPageMetrics(pageKey);
             var mostRecent = pageMetrics.OrderByDescending(x => x.RequestDate).FirstOrDefault();
             if (mostRecent?.PageData == null)
             {
@@ -92,9 +90,9 @@ namespace Umbraco.Community.Sustainability.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> CheckPage([FromQuery] int pageId)
+        public async Task<IActionResult> CheckPage([FromQuery] Guid pageKey)
         {
-            var contentItem = _contentQuery.Content(pageId);
+            var contentItem = _contentQuery.Content(pageKey);
             if (contentItem == null)
             {
                 return Ok("Page not found");
@@ -107,7 +105,7 @@ namespace Umbraco.Community.Sustainability.Controllers
         }
 
         [HttpPost]
-        public async Task<IActionResult> SavePageData([FromQuery] int pageId, [FromBody] SustainabilityResponse data)
+        public async Task<IActionResult> SavePageData([FromQuery] Guid pageKey, [FromBody] SustainabilityResponse data)
         {
             if (data.TotalSize == 0)
             {
@@ -116,7 +114,7 @@ namespace Umbraco.Community.Sustainability.Controllers
 
             var pageMetric = new PageMetric()
             {
-                NodeId = pageId,
+                NodeKey = pageKey,
                 RequestedBy = "Admin",
                 RequestDate = data.LastRunDate,
                 TotalSize = data.TotalSize,
@@ -129,7 +127,7 @@ namespace Umbraco.Community.Sustainability.Controllers
             return Ok(true);
         }
 
-        private int GetCarbonRatingOrder(string carbonRating)
+        private int GetCarbonRatingOrder(string? carbonRating)
         {
             switch (carbonRating)
             {
@@ -146,7 +144,6 @@ namespace Umbraco.Community.Sustainability.Controllers
                 case "E":
                     return 6;
                 case "F":
-                    return 7;
                 default:
                     return 7;
             }

--- a/src/Umbraco.Community.Sustainability/Migrations/02_AddCarbonRating.cs
+++ b/src/Umbraco.Community.Sustainability/Migrations/02_AddCarbonRating.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Community.Sustainability.Migrations
         {
             Logger.LogDebug("Running migration {MigrationStep}", "AddCarbonRating");
 
-            if (ColumnExists(PageMetric.TableName, "CarbonRating") == false)
+            if (ColumnExists(PageMetric.TableName, "CarbonRating"))
             {
                 Alter.Table(PageMetric.TableName).AddColumn("CarbonRating").AsString().Nullable().Do();
             }

--- a/src/Umbraco.Community.Sustainability/Migrations/02_AddCarbonRating.cs
+++ b/src/Umbraco.Community.Sustainability/Migrations/02_AddCarbonRating.cs
@@ -14,7 +14,7 @@ namespace Umbraco.Community.Sustainability.Migrations
         {
             Logger.LogDebug("Running migration {MigrationStep}", "AddCarbonRating");
 
-            if (ColumnExists(PageMetric.TableName, "CarbonRating"))
+            if (ColumnExists(PageMetric.TableName, "CarbonRating") == false)
             {
                 Alter.Table(PageMetric.TableName).AddColumn("CarbonRating").AsString().Nullable().Do();
             }

--- a/src/Umbraco.Community.Sustainability/Migrations/03_ChangeNodeIdToKey.cs
+++ b/src/Umbraco.Community.Sustainability/Migrations/03_ChangeNodeIdToKey.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Community.Sustainability.Schemas;
+
+namespace Umbraco.Community.Sustainability.Migrations
+{
+    public class ChangeNodeIdToNodeKey : MigrationBase
+    {
+        public ChangeNodeIdToNodeKey(IMigrationContext context) : base(context)
+        {
+        }
+
+        protected override void Migrate()
+        {
+            Logger.LogDebug("Running migration {MigrationStep}", "ChangeNodeIdToNodeKey");
+
+            if (ColumnExists(PageMetric.TableName, "NodeKey"))
+            {
+                Rename.Column("NodeId").OnTable(PageMetric.TableName).To("NodeKey").Do();
+                Alter.Table(PageMetric.TableName).AlterColumn("NodeKey").AsGuid().Nullable().Do();
+            }
+            else
+            {
+                Logger.LogDebug("The column NodeKey already exists, skipping");
+            }
+        }
+    }
+}

--- a/src/Umbraco.Community.Sustainability/Notifications/PageMetricsNotificationHandler.cs
+++ b/src/Umbraco.Community.Sustainability/Notifications/PageMetricsNotificationHandler.cs
@@ -49,6 +49,7 @@ namespace Umbraco.Community.Sustainability.Notifications
             migrationPlan.From(string.Empty)
                 .To<AddPageMetricsTable>("pagemetrics-init")
                 .To<AddCarbonRating>("pagemetrics-carbonrating");
+                // .To<ChangeNodeIdToNodeKey>("pagemetrics-nodeidtonodekey");
 
             // Go and upgrade our site (Will check if it needs to do the work or not)
             // Based on the current/latest step

--- a/src/Umbraco.Community.Sustainability/Notifications/PageMetricsNotificationHandler.cs
+++ b/src/Umbraco.Community.Sustainability/Notifications/PageMetricsNotificationHandler.cs
@@ -48,8 +48,8 @@ namespace Umbraco.Community.Sustainability.Notifications
             // Each step in the migration adds a unique value
             migrationPlan.From(string.Empty)
                 .To<AddPageMetricsTable>("pagemetrics-init")
-                .To<AddCarbonRating>("pagemetrics-carbonrating");
-                // .To<ChangeNodeIdToNodeKey>("pagemetrics-nodeidtonodekey");
+                .To<AddCarbonRating>("pagemetrics-carbonrating")
+                .To<ChangeNodeIdToNodeKey>("pagemetrics-nodeidtonodekey");
 
             // Go and upgrade our site (Will check if it needs to do the work or not)
             // Based on the current/latest step

--- a/src/Umbraco.Community.Sustainability/Schemas/PageMetricSchema.cs
+++ b/src/Umbraco.Community.Sustainability/Schemas/PageMetricSchema.cs
@@ -14,8 +14,8 @@ namespace Umbraco.Community.Sustainability.Schemas
         [Column("Id")]
         public int Id { get; set; }
 
-        [Column("NodeId")]
-        public int NodeId { get; set; }
+        [Column("NodeKey")]
+        public Guid? NodeKey { get; set; }
 
         [Ignore]
         public string? NodeName { get; set; }

--- a/src/Umbraco.Community.Sustainability/Services/PageMetricService.cs
+++ b/src/Umbraco.Community.Sustainability/Services/PageMetricService.cs
@@ -2,6 +2,7 @@ using Umbraco.Cms.Core;
 using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Community.Sustainability.Models;
 using Umbraco.Community.Sustainability.Schemas;
+using Umbraco.Extensions;
 
 namespace Umbraco.Community.Sustainability.Services
 {
@@ -9,7 +10,7 @@ namespace Umbraco.Community.Sustainability.Services
     {
         Task<IEnumerable<PageMetric>> GetOverviewMetrics();
         Task<AveragePageMetrics> GetAverageMetrics();
-        Task<IEnumerable<PageMetric>> GetPageMetrics(int pageId);
+        Task<IEnumerable<PageMetric>> GetPageMetrics(Guid pageKey);
         Task AddPageMetric(PageMetric pageMetric);
     }
 
@@ -32,11 +33,11 @@ namespace Umbraco.Community.Sustainability.Services
             var queryResults = await scope.Database.FetchAsync<PageMetric>();
 
             queryResults = queryResults.OrderByDescending(x => x.RequestDate).ToList();
-            queryResults = queryResults.DistinctBy(x => x.NodeId).ToList();
+            queryResults = queryResults.DistinctBy(x => x.NodeKey).ToList();
 
             foreach (var result in queryResults)
             {
-                var node = _contentQuery.Content(result.NodeId);
+                var node = _contentQuery.Content(result.NodeKey);
                 result.NodeName = node?.Name;
             }
 
@@ -61,10 +62,10 @@ namespace Umbraco.Community.Sustainability.Services
             return new();
         }
 
-        public async Task<IEnumerable<PageMetric>> GetPageMetrics(int pageId)
+        public async Task<IEnumerable<PageMetric>> GetPageMetrics(Guid pageKey)
         {
             using var scope = _scopeProvider.CreateScope();
-            var queryResults = await scope.Database.FetchAsync<PageMetric>($"SELECT * FROM {PageMetric.TableName} WHERE NodeId = @0", pageId);
+            var queryResults = await scope.Database.FetchAsync<PageMetric>($"SELECT * FROM {PageMetric.TableName} WHERE NodeKey = @0", pageKey);
             scope.Complete();
 
             return queryResults;

--- a/src/Umbraco.Community.Sustainability/wwwroot/UmbracoCommunitySustainability/js/sustainability-content-app.controller.js
+++ b/src/Umbraco.Community.Sustainability/wwwroot/UmbracoCommunitySustainability/js/sustainability-content-app.controller.js
@@ -5,6 +5,7 @@ angular.module('umbraco').controller('Umbraco.Sustainability.ContentApp.Controll
       let vm = this;
 
       $scope.id = "";
+      $scope.key = null;
       $scope.loading = true;
 
       vm.buttonState = undefined;
@@ -14,8 +15,9 @@ angular.module('umbraco').controller('Umbraco.Sustainability.ContentApp.Controll
 
       function init() {
         $scope.id = editorState.current.id;
+        $scope.key = editorState.current.key;
 
-        sustainabilityResource.getData($scope.id).then(function (data) {
+        sustainabilityResource.getData($scope.key).then(function (data) {
           $scope.sustainabilityData = data;
           updateResults();
         });
@@ -24,11 +26,11 @@ angular.module('umbraco').controller('Umbraco.Sustainability.ContentApp.Controll
       function checkPage() {
         vm.buttonState = "waiting";
 
-        sustainabilityResource.checkPage($scope.id).then(function (data) {
+        sustainabilityResource.checkPage($scope.key).then(function (data) {
           $scope.sustainabilityData = data;
           updateResults();
 
-          sustainabilityResource.saveResult($scope.id, $scope.sustainabilityData);
+          sustainabilityResource.saveResult($scope.key, $scope.sustainabilityData);
         });
       }
 

--- a/src/Umbraco.Community.Sustainability/wwwroot/UmbracoCommunitySustainability/js/sustainability.resource.js
+++ b/src/Umbraco.Community.Sustainability/wwwroot/UmbracoCommunitySustainability/js/sustainability.resource.js
@@ -15,9 +15,9 @@
       calculateGrade: calculateGrade
     };
 
-    function getData(pageId) {
+    function getData(pageKey) {
       return umbRequestHelper.resourcePromise(
-        $http.get(`${apiUrl}GetPageData?pageId=${pageId}`),
+        $http.get(`${apiUrl}GetPageData?pageKey=${pageKey}`),
         'Failed getting sustainability data'
       );
     };
@@ -45,16 +45,16 @@
       );
     };
 
-    function checkPage(pageId) {
+    function checkPage(pageKey) {
       return umbRequestHelper.resourcePromise(
-        $http.get(`${apiUrl}CheckPage?pageId=${pageId}`),
+        $http.get(`${apiUrl}CheckPage?pageKey=${pageKey}`),
         'Failed to run sustainability check'
       );
     };
 
-    function saveResult(pageId, data) {
+    function saveResult(pageKey, data) {
       return umbRequestHelper.resourcePromise(
-        $http.post(`${apiUrl}SavePageData?pageId=${pageId}`, data),
+        $http.post(`${apiUrl}SavePageData?pageKey=${pageKey}`, data),
         'Failed to save sustainability data'
       );
     };


### PR DESCRIPTION
NodeId (`int`) column has been removed/replaced with NodeKey (`Guid`) for better migrations to v14.

SQLite doesn't support `Alter.Table()` so local test environments will need to be recreated.