### PR TITLE
Added media library warnings

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -49,6 +49,28 @@ Add the package to an existing Umbraco website from nuget:
 
 Once added, a new Content App will be available alongside your Umbraco pages allowing you to trigger a sustainability report.
 
+## Configuration
+
+You will need to add the following configuration to you appSettings.json file. 
+The AcceptedFileTypes are the media types that you can create in the media library, not the file extensions of your files
+
+  ```
+  "Umbraco": {
+    "CMS":{
+        "MediaLibrary" : {
+            "Optimisation":{
+                "Enable" : bool,
+                "AcceptedFileTypes" : 
+                {
+                    "<<Media File Type here>>" : "<<MAX file size in bytes here>>",
+                    "<<Media File Type here>>" : "<<MAX file size in bytes here>>"
+                }
+            }
+        }
+    }
+  }
+  ```
+
 ## Contributing
 
 Contributions to this package are most welcome! Please read the [Contributing Guidelines](CONTRIBUTING.md) for how to get involved.

--- a/docs/README_nuget.md
+++ b/docs/README_nuget.md
@@ -33,8 +33,31 @@ Add the package to an existing Umbraco website from NuGet:
 
 Once added, a new Content App will be available alongside your Umbraco pages allowing you to trigger a sustainability report.
 
+## Configuration
+
+You will need to add the following configuration to you appSettings.json file. 
+The AcceptedFileTypes are the media types that you can create in the media library, not the file extensions of your files
+
+  ```
+  "Umbraco": {
+    "CMS":{
+        "MediaLibrary" : {
+            "Optimisation":{
+                "Enable" : bool,
+                "AcceptedFileTypes" : 
+                {
+                    "<<Media File Type here>>" : "<<MAX file size in bytes here>>",
+                    "<<Media File Type here>>" : "<<MAX file size in bytes here>>"
+                }
+            }
+        }
+    }
+  }
+  ```
+
+
 ## License
 
-Copyright &copy; [Rick Butterfield](https://github.com/rickbutterfield), [Thomas Morris](https://github.com/tcmorris) and other contributors.
+Copyright &copy; [Rick Butterfield](https://github.com/rickbutterfield), [Thomas Morris](https://github.com/tcmorris), [Tony Gledhill](https://github.com/tony-gledhill) and other contributors.
 
 Licensed under the [MIT License](https://github.com/rickbutterfield/Umbraco.Community.Sustainability/blob/main/LICENSE.md).

--- a/src/Umbraco.Community.Sustainability.TestSite.13.x/appsettings.json
+++ b/src/Umbraco.Community.Sustainability.TestSite.13.x/appsettings.json
@@ -16,6 +16,12 @@
   },
   "Umbraco": {
     "CMS": {
+      "MediaLibrary": {
+        "Optimisation": {
+          "Enabled": true,
+          "AcceptedFileTypes": { "Image": "500000" }
+        }
+      },
       "Global": {
         "Id": "4bf4d037-bbbd-4247-abce-fc2a66b9a1e6",
         "SanitizeTinyMce": true

--- a/src/Umbraco.Community.Sustainability/Configuration/MediaLibraryOptions.cs
+++ b/src/Umbraco.Community.Sustainability/Configuration/MediaLibraryOptions.cs
@@ -1,0 +1,10 @@
+namespace Umbraco.Community.Sustainability.Configuration
+{
+    public class MediaLibraryOptions
+    {
+        public const string SectionAlias = "Umbraco:CMS:MediaLibrary:Optimisation";
+
+        public bool Enabled { get; set; }
+        public Dictionary<string, string> AcceptedFileTypes { get; set; } = new Dictionary<string, string>();
+    }
+}

--- a/src/Umbraco.Community.Sustainability/Notifications/MediaTreeNodeRenderingNotificationHandler.cs
+++ b/src/Umbraco.Community.Sustainability/Notifications/MediaTreeNodeRenderingNotificationHandler.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Community.Sustainability.Services;
+
+namespace Umbraco.Community.Sustainability.Notifications
+{
+    public class MediaTreeNodeRenderingNotificationHandler : INotificationHandler<TreeNodesRenderingNotification>
+    {
+        private readonly ILogger<MediaTreeNodeRenderingNotificationHandler> _logger;
+        private readonly IImageSizeService _imageSizeService;
+        private readonly IMediaLibraryService _mediaLibraryService;
+
+        public MediaTreeNodeRenderingNotificationHandler(ILogger<MediaTreeNodeRenderingNotificationHandler> logger,
+            IImageSizeService imageService, IMediaLibraryService mediaLibraryService)
+        {
+            _logger = logger;
+            _imageSizeService = imageService;
+            _mediaLibraryService = mediaLibraryService;
+        }
+
+        public void Handle(TreeNodesRenderingNotification notification)
+        {
+            if (notification.TreeAlias == Cms.Core.Constants.Trees.Media)
+            {
+                foreach (var node in notification.Nodes)
+                {
+                    int.TryParse(node?.Id?.ToString(), out int nodeId);
+
+                    if (nodeId > 0)
+                    {
+                        var mediaItem = _mediaLibraryService.GetMediaLibraryFile(nodeId);
+
+                        if (mediaItem == null)
+                        {
+                            continue;
+                        }
+
+                        var acceptedFileType = _imageSizeService.AcceptedFileExtension(mediaItem);
+                        if (!acceptedFileType)
+                        {
+                            continue;
+                        }
+
+                        var acceptedFileSize = _imageSizeService.AcceptedFileSize(mediaItem);
+                        if (!acceptedFileSize)
+                        {
+                            node.CssClasses.Add("image-size-css");
+                            node.Icon = "icon-thumb-down";
+                            _logger.LogWarning($"Image Size Warning: Node Id: {node.Id} || Node Name: {node.Name}");
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Umbraco.Community.Sustainability/Services/MediaItemService.cs
+++ b/src/Umbraco.Community.Sustainability/Services/MediaItemService.cs
@@ -1,0 +1,69 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Community.Sustainability.Configuration;
+using Umbraco.Extensions;
+
+namespace Umbraco.Community.Sustainability.Services
+{
+    public interface IImageSizeService
+    {
+        bool AcceptedFileSize(IPublishedContent content);
+        bool AcceptedFileExtension(IPublishedContent content);
+    }
+    public class ImageSizeService : IImageSizeService
+    {
+        private readonly ILogger<ImageSizeService> _logger;
+        private readonly IOptions<MediaLibraryOptions> _settings;
+
+        public ImageSizeService(ILogger<ImageSizeService> logger, IOptions<MediaLibraryOptions> settings)
+        {
+            _logger = logger;
+            _settings = settings;
+        }
+
+        public bool AcceptedFileExtension(IPublishedContent content)
+        {
+            try
+            {
+                var fileTypes = _settings.Value.AcceptedFileTypes;
+
+                return fileTypes.Any(x => x.Key.ToLowerInvariant() == content.ContentType.Alias.ToLowerInvariant());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message, ex);
+                throw;
+            }
+        }
+
+        public bool AcceptedFileSize(IPublishedContent content)
+        {
+            try
+            {
+                var imageSize = content.Value<int>("umbracoBytes");
+                var fileTypes = _settings.Value.AcceptedFileTypes;
+                var acceptedFileSize = fileTypes.Where(x => x.Key.ToLowerInvariant() == content.ContentType.Alias.ToLowerInvariant()).FirstOrDefault();
+
+                if (acceptedFileSize.Equals(default(KeyValuePair<string, string>)))
+                {
+                    return false;
+                }
+
+                long maxAcceptedFileSize = (long)Convert.ToDouble(acceptedFileSize.Value);
+
+                if (imageSize >= maxAcceptedFileSize)
+                {
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message, ex);
+                throw;
+            }
+        }
+    }
+}

--- a/src/Umbraco.Community.Sustainability/Services/MediaLibraryService.cs
+++ b/src/Umbraco.Community.Sustainability/Services/MediaLibraryService.cs
@@ -1,0 +1,28 @@
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Web;
+
+namespace Umbraco.Community.Sustainability.Services
+{
+    public interface IMediaLibraryService
+    {
+        IPublishedContent? GetMediaLibraryFile(int nodeId);
+    }
+
+    public class MediaLibraryService : IMediaLibraryService
+    {
+        private readonly IUmbracoContextFactory _umbracoContextFactory;
+
+        public MediaLibraryService(IUmbracoContextFactory umbracoContextFactor)
+        {
+            _umbracoContextFactory = umbracoContextFactor;
+        }
+        public IPublishedContent? GetMediaLibraryFile(int nodeId)
+        {
+            using var umbracoContextReference = _umbracoContextFactory.EnsureUmbracoContext();
+
+            var mediaItem = umbracoContextReference?.UmbracoContext?.Media?.GetById(nodeId);
+
+            return mediaItem ?? null;
+        }
+    }
+}

--- a/src/Umbraco.Community.Sustainability/SustainabilityComposer.cs
+++ b/src/Umbraco.Community.Sustainability/SustainabilityComposer.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Community.Sustainability.Configuration;
 using Umbraco.Community.Sustainability.ContentApps;
 using Umbraco.Community.Sustainability.Notifications;
 using Umbraco.Community.Sustainability.Sections;
@@ -30,6 +31,12 @@ namespace Umbraco.Community.Sustainability
 
             builder.Services.AddScoped<IPageMetricService, PageMetricService>();
             builder.Services.AddSingleton<ISustainabilityService, SustainabilityService>();
+
+            builder.Services.AddOptions<MediaLibraryOptions>().Bind(builder.Config.GetSection(MediaLibraryOptions.SectionAlias));
+            builder.Services.AddSingleton<IImageSizeService, ImageSizeService>();
+            builder.Services.AddSingleton<IMediaLibraryService, MediaLibraryService>();
+            builder.AddNotificationHandler<TreeNodesRenderingNotification, MediaTreeNodeRenderingNotificationHandler>();
+
         }
     }
 }

--- a/src/Umbraco.Community.Sustainability/SustainabilityManifestFilter.cs
+++ b/src/Umbraco.Community.Sustainability/SustainabilityManifestFilter.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Community.Sustainability
                 {
                     // List any Stylesheet files
                     // Urls should start '/App_Plugins/UmbracoCommunitySustainability/' not '/wwwroot/Umbraco.Community.Sustainability/', e.g.
-                    // "/App_Plugins/UmbracoCommunitySustainability/Styles/styles.css"
+                     "/App_Plugins/UmbracoCommunitySustainability/Styles/medialibrary.css"
                 }
             });
         }

--- a/src/Umbraco.Community.Sustainability/Umbraco.Community.Sustainability.csproj
+++ b/src/Umbraco.Community.Sustainability/Umbraco.Community.Sustainability.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>Umbraco.Community.Sustainability</RootNamespace>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 
-    <VersionPrefix>1.0.3</VersionPrefix>
+    <VersionPrefix>1.0.4</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <Authors>Umbraco Sustainability Community Team</Authors>
     <Copyright>$([System.DateTime]::UtcNow.ToString(`yyyy`)) © Umbraco Sustainability Community Team</Copyright>
@@ -57,6 +57,5 @@
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
-  </ItemGroup>
-  
+  </ItemGroup>  
 </Project>

--- a/src/Umbraco.Community.Sustainability/wwwroot/UmbracoCommunitySustainability/styles/medialibrary.css
+++ b/src/Umbraco.Community.Sustainability/wwwroot/UmbracoCommunitySustainability/styles/medialibrary.css
@@ -1,0 +1,4 @@
+.image-size-css {
+  background-color: red;
+  color: white;
+}


### PR DESCRIPTION
A feature has now been added to highlight media items that are not complying with explicit file sizes that have been set by a developer. 

An editor can still upload content into the media library without restrictions, but offending items are now highlighted in red and have the media icon replaced with a thumbs down icon. 

Developers are able to set media library types, along with the maximum size in bytes, int he `appSettings.json` This allows for custom media types to be included as well. 