### PR TITLE
Fix reference to co2 to v0.15 rather than 'latest' due to changes intrroduced in v0.16 of the library

### DIFF
--- a/src/Umbraco.Community.Sustainability/wwwroot/UmbracoCommunitySustainability/js/resource-checker.js
+++ b/src/Umbraco.Community.Sustainability/wwwroot/UmbracoCommunitySustainability/js/resource-checker.js
@@ -1,4 +1,4 @@
-import { co2, hosting } from 'https://cdn.skypack.dev/@tgwf/co2';
+import { co2, hosting } from 'https://cdn.skypack.dev/@tgwf/co2@0.15';
 
 scrollPage();
 


### PR DESCRIPTION
Fixes #19 

A recent release of CO2.js seems to have changed the default json model being passed down for emissions, although the release notes say this should not happen by default until September. A comparison of the raw json models from v0.15 of CO2.js and v0.16 of CO2.js show the gridIntensity values have all changed from single discrete values to nested values, which is why deserializing fails on the .net side.

![image](https://github.com/rickbutterfield/Umbraco.Community.Sustainability/assets/134947113/52ea0464-8b44-42bc-a9e8-ea4f79424455)

This fix is a simple one for now and instructs resource-checker.js to lock itself to the previous release v0.15 from the remote CDN rather than always just taking the latest version, restoring previous behaviour and fixing the error. While I did explore updating the .cs models which would also resolve this, given they could change the behaviour of this remote javascript library further at any time it seems safer to lock it to a version which is known to work with the release of the package.

The PR fixes it in the v1 branch for now as this is likely to impact most users.

(Or hopefully I've got this all correct with my research anyway!)

Thanks,
Terence