### PR TITLE
Add health checks for sustainability monitoring

### DIFF
--- a/src/Umbraco.Community.Sustainability/HealthChecks/CarbonRatingHealthCheck.cs
+++ b/src/Umbraco.Community.Sustainability/HealthChecks/CarbonRatingHealthCheck.cs
@@ -1,0 +1,114 @@
+using Umbraco.Cms.Core.HealthChecks;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Community.Sustainability.Helpers;
+using Umbraco.Community.Sustainability.Services;
+
+namespace Umbraco.Community.Sustainability.HealthChecks
+{
+    [HealthCheck(
+        "2C5B4F1B-7D3E-4A5F-8B9C-6E7F8A9B0C1D",
+        "Site Carbon Rating",
+        Description = "Evaluates your website's overall carbon footprint based on average page metrics.",
+        Group = "Sustainability")]
+    public class CarbonRatingHealthCheck : HealthCheck
+    {
+        private readonly IPageMetricService _pageMetricService;
+        private readonly ILocalizedTextService _textService;
+
+        public CarbonRatingHealthCheck(
+            IPageMetricService pageMetricService,
+            ILocalizedTextService textService)
+        {
+            _pageMetricService = pageMetricService;
+            _textService = textService;
+        }
+
+        public override async Task<IEnumerable<HealthCheckStatus>> GetStatusAsync()
+        {
+            var averageMetrics = await _pageMetricService.GetAverageMetrics();
+
+            // No data available
+            if (!averageMetrics.Emissions.HasValue || averageMetrics.Emissions == 0)
+            {
+                return new[]
+                {
+                    new HealthCheckStatus(
+                        "No sustainability data available yet.")
+                    {
+                        ResultType = StatusResultType.Info,
+                        Description = "Run sustainability checks on your pages to see your carbon rating. " +
+                                     "Visit any content page and use the 'Check Sustainability' action."
+                    }
+                };
+            }
+
+            var grade = CarbonRatingHelper.CalculateGrade((double)averageMetrics.Emissions.Value);
+            var emissionsFormatted = $"{averageMetrics.Emissions.Value:F3}g";
+            var pageSizeFormatted = $"{(averageMetrics.PageSize ?? 0) / 1024:F2}KB";
+
+            var message = $"Your site's average carbon rating is: {grade}\n\n" +
+                         $"Average emissions: {emissionsFormatted} CO₂ per page view\n" +
+                         $"Average page size: {pageSizeFormatted}";
+
+            // Determine result type and add recommendations
+            StatusResultType resultType;
+            string? recommendations = null;
+
+            switch (grade)
+            {
+                case "A+":
+                case "A":
+                    resultType = StatusResultType.Success;
+                    recommendations = "Excellent! Your site has a very low carbon footprint. Keep up the good work!";
+                    break;
+
+                case "B":
+                case "C":
+                    resultType = StatusResultType.Success;
+                    recommendations = "Good performance. Consider optimizing images and reducing JavaScript to improve further.";
+                    break;
+
+                case "D":
+                    resultType = StatusResultType.Warning;
+                    recommendations = "Your site's carbon footprint could be improved. Consider:\n" +
+                                    "• Optimizing and compressing images\n" +
+                                    "• Minimizing JavaScript and CSS\n" +
+                                    "• Implementing lazy loading for media\n" +
+                                    "• Using modern image formats (WebP, AVIF)";
+                    break;
+
+                case "E":
+                case "F":
+                    resultType = StatusResultType.Error;
+                    recommendations = "Your site has a high carbon footprint. Take action:\n" +
+                                    "• Review and optimize large images and media files\n" +
+                                    "• Remove unused JavaScript libraries and CSS\n" +
+                                    "• Enable compression and caching\n" +
+                                    "• Consider using a CDN\n" +
+                                    "• Audit third-party scripts and tracking pixels";
+                    break;
+
+                default:
+                    resultType = StatusResultType.Info;
+                    break;
+            }
+
+            return new[]
+            {
+                new HealthCheckStatus(message)
+                {
+                    ResultType = resultType,
+                    Description = recommendations
+                }
+            };
+        }
+
+        public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
+        {
+            return new HealthCheckStatus("No actions available for this health check.")
+            {
+                ResultType = StatusResultType.Info
+            };
+        }
+    }
+}

--- a/src/Umbraco.Community.Sustainability/HealthChecks/CarbonRatingHealthCheck.cs
+++ b/src/Umbraco.Community.Sustainability/HealthChecks/CarbonRatingHealthCheck.cs
@@ -13,14 +13,10 @@ namespace Umbraco.Community.Sustainability.HealthChecks
     public class CarbonRatingHealthCheck : HealthCheck
     {
         private readonly IPageMetricService _pageMetricService;
-        private readonly ILocalizedTextService _textService;
 
-        public CarbonRatingHealthCheck(
-            IPageMetricService pageMetricService,
-            ILocalizedTextService textService)
+        public CarbonRatingHealthCheck(IPageMetricService pageMetricService)
         {
             _pageMetricService = pageMetricService;
-            _textService = textService;
         }
 
         public override async Task<IEnumerable<HealthCheckStatus>> GetStatusAsync()

--- a/src/Umbraco.Community.Sustainability/HealthChecks/CarbonRatingHealthCheck.cs
+++ b/src/Umbraco.Community.Sustainability/HealthChecks/CarbonRatingHealthCheck.cs
@@ -1,5 +1,4 @@
 using Umbraco.Cms.Core.HealthChecks;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Community.Sustainability.Helpers;
 using Umbraco.Community.Sustainability.Services;
 

--- a/src/Umbraco.Community.Sustainability/HealthChecks/GreenHostingHealthCheck.cs
+++ b/src/Umbraco.Community.Sustainability/HealthChecks/GreenHostingHealthCheck.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.HealthChecks;
 using Umbraco.Cms.Core.Hosting;
 using Umbraco.Cms.Core.Services;
@@ -15,16 +16,16 @@ namespace Umbraco.Community.Sustainability.HealthChecks
     {
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IHostingEnvironment _hostingEnvironment;
-        private readonly ILocalizedTextService _textService;
+        private readonly ILogger<GreenHostingHealthCheck> _logger;
 
         public GreenHostingHealthCheck(
             IHttpClientFactory httpClientFactory,
             IHostingEnvironment hostingEnvironment,
-            ILocalizedTextService textService)
+            ILogger<GreenHostingHealthCheck> logger)
         {
             _httpClientFactory = httpClientFactory;
             _hostingEnvironment = hostingEnvironment;
-            _textService = textService;
+            _logger = logger;
         }
 
         public override async Task<IEnumerable<HealthCheckStatus>> GetStatusAsync()
@@ -119,13 +120,15 @@ namespace Umbraco.Community.Sustainability.HealthChecks
             }
             catch (Exception ex)
             {
+                _logger.LogError(ex, "Error checking green hosting status for {Hostname}", hostname);
+
                 return new[]
                 {
                     new HealthCheckStatus(
                         "An error occurred while checking green hosting status.")
                     {
                         ResultType = StatusResultType.Warning,
-                        Description = ex.Message
+                        Description = "Unable to verify green hosting status. Please check the logs for more details."
                     }
                 };
             }

--- a/src/Umbraco.Community.Sustainability/HealthChecks/GreenHostingHealthCheck.cs
+++ b/src/Umbraco.Community.Sustainability/HealthChecks/GreenHostingHealthCheck.cs
@@ -1,9 +1,9 @@
 using System.Net.Http.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.HealthChecks;
 using Umbraco.Cms.Core.Hosting;
-using Umbraco.Cms.Core.Services;
 
 namespace Umbraco.Community.Sustainability.HealthChecks
 {
@@ -67,7 +67,22 @@ namespace Umbraco.Community.Sustainability.HealthChecks
 
                 var result = await response.Content.ReadFromJsonAsync<GreenWebCheckResponse>();
 
-                if (result?.Green == true)
+                if (result is null || result.Green is null)
+                {
+                    _logger.LogWarning("Unable to parse green hosting response for {Hostname}. Response was null or missing required fields.", hostname);
+
+                    return new[]
+                    {
+                        new HealthCheckStatus(
+                            "Unable to verify green hosting status because the API response could not be parsed.")
+                        {
+                            ResultType = StatusResultType.Warning,
+                            Description = "The Green Web Foundation API returned an unexpected response format."
+                        }
+                    };
+                }
+
+                if (result.Green == true)
                 {
                     var message = $"✓ Your site is hosted on green infrastructure!";
                     if (!string.IsNullOrEmpty(result.HostingProvider))
@@ -118,6 +133,20 @@ namespace Umbraco.Community.Sustainability.HealthChecks
                     }
                 };
             }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex, "Unable to parse green hosting response for {Hostname}", hostname);
+
+                return new[]
+                {
+                    new HealthCheckStatus(
+                        "Unable to verify green hosting status because the API response could not be parsed.")
+                    {
+                        ResultType = StatusResultType.Warning,
+                        Description = "The Green Web Foundation API returned invalid JSON or an unexpected response format."
+                    }
+                };
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error checking green hosting status for {Hostname}", hostname);
@@ -155,7 +184,7 @@ namespace Umbraco.Community.Sustainability.HealthChecks
         private class GreenWebCheckResponse
         {
             [JsonPropertyName("green")]
-            public bool Green { get; set; }
+            public bool? Green { get; set; }
 
             [JsonPropertyName("hosted_by")]
             public string? HostingProvider { get; set; }

--- a/src/Umbraco.Community.Sustainability/HealthChecks/GreenHostingHealthCheck.cs
+++ b/src/Umbraco.Community.Sustainability/HealthChecks/GreenHostingHealthCheck.cs
@@ -1,0 +1,164 @@
+using System.Net.Http.Json;
+using System.Text.Json.Serialization;
+using Umbraco.Cms.Core.HealthChecks;
+using Umbraco.Cms.Core.Hosting;
+using Umbraco.Cms.Core.Services;
+
+namespace Umbraco.Community.Sustainability.HealthChecks
+{
+    [HealthCheck(
+        "1B4A3E0A-6C2D-4F3E-9A8B-7C5D6E4F3A2B",
+        "Green Hosting",
+        Description = "Checks if your website is hosted on green infrastructure using The Green Web Foundation API.",
+        Group = "Sustainability")]
+    public class GreenHostingHealthCheck : HealthCheck
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IHostingEnvironment _hostingEnvironment;
+        private readonly ILocalizedTextService _textService;
+
+        public GreenHostingHealthCheck(
+            IHttpClientFactory httpClientFactory,
+            IHostingEnvironment hostingEnvironment,
+            ILocalizedTextService textService)
+        {
+            _httpClientFactory = httpClientFactory;
+            _hostingEnvironment = hostingEnvironment;
+            _textService = textService;
+        }
+
+        public override async Task<IEnumerable<HealthCheckStatus>> GetStatusAsync()
+        {
+            var hostname = _hostingEnvironment.ApplicationMainUrl?.Host;
+
+            if (string.IsNullOrEmpty(hostname))
+            {
+                return new[]
+                {
+                    new HealthCheckStatus(
+                        "Unable to determine hostname from application URL.")
+                    {
+                        ResultType = StatusResultType.Warning
+                    }
+                };
+            }
+
+            try
+            {
+                var httpClient = _httpClientFactory.CreateClient("GreenWebFoundation");
+                httpClient.Timeout = TimeSpan.FromSeconds(10);
+
+                var response = await httpClient.GetAsync(
+                    $"https://api.thegreenwebfoundation.org/greencheck/{hostname}");
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    return new[]
+                    {
+                        new HealthCheckStatus(
+                            "Unable to check green hosting status. The Green Web Foundation API returned an error.")
+                        {
+                            ResultType = StatusResultType.Warning,
+                            Description = $"HTTP {response.StatusCode}"
+                        }
+                    };
+                }
+
+                var result = await response.Content.ReadFromJsonAsync<GreenWebCheckResponse>();
+
+                if (result?.Green == true)
+                {
+                    var message = $"✓ Your site is hosted on green infrastructure!";
+                    if (!string.IsNullOrEmpty(result.HostingProvider))
+                    {
+                        message += $"\n\nHosting provider: {result.HostingProvider}";
+                    }
+
+                    return new[]
+                    {
+                        new HealthCheckStatus(message)
+                        {
+                            ResultType = StatusResultType.Success,
+                            Description = "Your hosting provider uses renewable energy or carbon offsets."
+                        }
+                    };
+                }
+                else
+                {
+                    return new[]
+                    {
+                        new HealthCheckStatus(
+                            "Your site is not currently hosted on verified green infrastructure.")
+                        {
+                            ResultType = StatusResultType.Warning,
+                            Description = "Consider switching to a green hosting provider to reduce your website's environmental impact.",
+                            Actions = new[]
+                            {
+                                new HealthCheckAction("findGreenHost", Id)
+                                {
+                                    Name = "Find Green Hosting Providers",
+                                    Description = "Browse The Green Web Foundation's directory of green hosting providers.",
+                                    ValueRequired = false
+                                }
+                            }
+                        }
+                    };
+                }
+            }
+            catch (TaskCanceledException)
+            {
+                return new[]
+                {
+                    new HealthCheckStatus(
+                        "The green hosting check timed out.")
+                    {
+                        ResultType = StatusResultType.Warning,
+                        Description = "Unable to reach The Green Web Foundation API."
+                    }
+                };
+            }
+            catch (Exception ex)
+            {
+                return new[]
+                {
+                    new HealthCheckStatus(
+                        "An error occurred while checking green hosting status.")
+                    {
+                        ResultType = StatusResultType.Warning,
+                        Description = ex.Message
+                    }
+                };
+            }
+        }
+
+        public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
+        {
+            if (action.Alias == "findGreenHost")
+            {
+                return new HealthCheckStatus(
+                    "Opening The Green Web Foundation directory...")
+                {
+                    ResultType = StatusResultType.Info,
+                    Description = "Visit: https://www.thegreenwebfoundation.org/directory/"
+                };
+            }
+
+            return new HealthCheckStatus("Unknown action.")
+            {
+                ResultType = StatusResultType.Error
+            };
+        }
+
+        private class GreenWebCheckResponse
+        {
+            [JsonPropertyName("green")]
+            public bool Green { get; set; }
+
+            [JsonPropertyName("hosted_by")]
+            public string? HostingProvider { get; set; }
+
+            [JsonPropertyName("url")]
+            public string? Url { get; set; }
+        }
+    }
+}

--- a/src/Umbraco.Community.Sustainability/HealthChecks/PageCoverageHealthCheck.cs
+++ b/src/Umbraco.Community.Sustainability/HealthChecks/PageCoverageHealthCheck.cs
@@ -48,11 +48,11 @@ namespace Umbraco.Community.Sustainability.HealthChecks
             // Get coverage data
             var coverageData = await _pageMetricService.GetPageCoverageData(_settings.StaleDays);
             var testedCount = coverageData.TestedPageCount;
-            var staleCount = coverageData.StalePageCount;
-            var coveragePercentage = (testedCount * 100.0) / totalPublished;
+            var staleCount = Math.Min(coverageData.StalePageCount, testedCount);
+            var coveragePercentage = Math.Min((testedCount * 100.0) / totalPublished, 100.0);
 
             var message = $"Sustainability test coverage: {coveragePercentage:F1}%\n\n" +
-                         $"Tested pages: {testedCount} of {totalPublished}";
+                         $"Tested published pages: {testedCount} of {totalPublished}";
 
             if (staleCount > 0)
             {

--- a/src/Umbraco.Community.Sustainability/HealthChecks/PageCoverageHealthCheck.cs
+++ b/src/Umbraco.Community.Sustainability/HealthChecks/PageCoverageHealthCheck.cs
@@ -1,0 +1,114 @@
+using Microsoft.Extensions.Options;
+using Umbraco.Cms.Core.HealthChecks;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Community.Sustainability.Models;
+using Umbraco.Community.Sustainability.Services;
+
+namespace Umbraco.Community.Sustainability.HealthChecks
+{
+    [HealthCheck(
+        "3D6C5E2C-8E4F-4B66-9C0D-7F8A9B0C1D2E",
+        "Page Coverage",
+        Description = "Reports on the percentage of published pages that have been tested for sustainability.",
+        Group = "Sustainability")]
+    public class PageCoverageHealthCheck : HealthCheck
+    {
+        private readonly IPageMetricService _pageMetricService;
+        private readonly IContentService _contentService;
+        private readonly ILocalizedTextService _textService;
+        private readonly SustainabilityHealthCheckSettings _settings;
+
+        public PageCoverageHealthCheck(
+            IPageMetricService pageMetricService,
+            IContentService contentService,
+            ILocalizedTextService textService,
+            IOptions<SustainabilityHealthCheckSettings> settings)
+        {
+            _pageMetricService = pageMetricService;
+            _contentService = contentService;
+            _textService = textService;
+            _settings = settings.Value;
+        }
+
+        public override async Task<IEnumerable<HealthCheckStatus>> GetStatusAsync()
+        {
+            // Get total published pages
+            var totalPublished = _contentService.CountPublished();
+
+            if (totalPublished == 0)
+            {
+                return new[]
+                {
+                    new HealthCheckStatus(
+                        "No published pages found.")
+                    {
+                        ResultType = StatusResultType.Info,
+                        Description = "Publish some content to see sustainability coverage statistics."
+                    }
+                };
+            }
+
+            // Get coverage data
+            var coverageData = await _pageMetricService.GetPageCoverageData(_settings.StaleDays);
+            var testedCount = coverageData.TestedPageCount;
+            var staleCount = coverageData.StalePageCount;
+            var coveragePercentage = (testedCount * 100.0) / totalPublished;
+
+            var message = $"Sustainability test coverage: {coveragePercentage:F1}%\n\n" +
+                         $"Tested pages: {testedCount} of {totalPublished}";
+
+            if (staleCount > 0)
+            {
+                message += $"\nStale metrics: {staleCount} page(s) not tested in {_settings.StaleDays} days";
+            }
+
+            // Determine result type based on coverage and staleness
+            StatusResultType resultType;
+            string? description;
+
+            if (coveragePercentage >= 80 && staleCount == 0)
+            {
+                resultType = StatusResultType.Success;
+                description = "Excellent coverage! Most of your pages have recent sustainability metrics.";
+            }
+            else if (coveragePercentage >= 50)
+            {
+                resultType = StatusResultType.Warning;
+                if (staleCount > 0)
+                {
+                    description = $"Good coverage, but {staleCount} page(s) have stale metrics (older than {_settings.StaleDays} days). " +
+                                 "Consider re-testing pages regularly to track improvements.";
+                }
+                else
+                {
+                    description = "Good coverage, but consider testing more pages to get a complete picture of your site's sustainability.";
+                }
+            }
+            else
+            {
+                resultType = StatusResultType.Error;
+                description = $"Low coverage. Only {testedCount} of {totalPublished} pages have been tested. " +
+                             "Run sustainability checks on more pages to understand your site's environmental impact. " +
+                             "You can check individual pages from the content editor, or use the Site Check feature " +
+                             "to test all pages at once.";
+            }
+
+            return new[]
+            {
+                new HealthCheckStatus(message)
+                {
+                    ResultType = resultType,
+                    Description = description
+                }
+            };
+        }
+
+        public override HealthCheckStatus ExecuteAction(HealthCheckAction action)
+        {
+            return new HealthCheckStatus("No actions available for this health check.")
+            {
+                ResultType = StatusResultType.Info
+            };
+        }
+    }
+}

--- a/src/Umbraco.Community.Sustainability/HealthChecks/PageCoverageHealthCheck.cs
+++ b/src/Umbraco.Community.Sustainability/HealthChecks/PageCoverageHealthCheck.cs
@@ -15,18 +15,15 @@ namespace Umbraco.Community.Sustainability.HealthChecks
     {
         private readonly IPageMetricService _pageMetricService;
         private readonly IContentService _contentService;
-        private readonly ILocalizedTextService _textService;
         private readonly SustainabilityHealthCheckSettings _settings;
 
         public PageCoverageHealthCheck(
             IPageMetricService pageMetricService,
             IContentService contentService,
-            ILocalizedTextService textService,
             IOptions<SustainabilityHealthCheckSettings> settings)
         {
             _pageMetricService = pageMetricService;
             _contentService = contentService;
-            _textService = textService;
             _settings = settings.Value;
         }
 

--- a/src/Umbraco.Community.Sustainability/Helpers/CarbonRatingHelper.cs
+++ b/src/Umbraco.Community.Sustainability/Helpers/CarbonRatingHelper.cs
@@ -1,0 +1,25 @@
+namespace Umbraco.Community.Sustainability.Helpers
+{
+    /// <summary>
+    /// Helper class for calculating carbon ratings based on CO2 emissions.
+    /// Thresholds mirror those defined in resource-checker.js.
+    /// </summary>
+    public static class CarbonRatingHelper
+    {
+        /// <summary>
+        /// Calculates the carbon rating grade (A+ to F) based on CO2 per page view in grams.
+        /// </summary>
+        /// <param name="co2PerView">CO2 emissions per page view in grams</param>
+        /// <returns>Grade from A+ (best) to F (worst)</returns>
+        public static string CalculateGrade(double co2PerView)
+        {
+            if (co2PerView < 0.095) return "A+";
+            if (co2PerView < 0.186) return "A";
+            if (co2PerView < 0.341) return "B";
+            if (co2PerView < 0.493) return "C";
+            if (co2PerView < 0.656) return "D";
+            if (co2PerView < 0.846) return "E";
+            return "F";
+        }
+    }
+}

--- a/src/Umbraco.Community.Sustainability/Migrations/04_ChangePageDataToNVarcharMax.cs
+++ b/src/Umbraco.Community.Sustainability/Migrations/04_ChangePageDataToNVarcharMax.cs
@@ -1,0 +1,43 @@
+using Microsoft.Extensions.Logging;
+using NPoco;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Umbraco.Community.Sustainability.Schemas;
+
+namespace Umbraco.Community.Sustainability.Migrations
+{
+    public class ChangePageDataToNVarcharMax : AsyncMigrationBase
+    {
+        public ChangePageDataToNVarcharMax(IMigrationContext context) : base(context)
+        {
+        }
+
+        protected override Task MigrateAsync()
+        {
+            Logger.LogDebug("Running migration {MigrationStep}", "ChangePageDataToNVarcharMax");
+
+            // SQLite doesn't need this - text is already unlimited
+            if (DatabaseType == DatabaseType.SQLite)
+            {
+                Logger.LogDebug("SQLite detected - text columns are already unlimited, skipping");
+                return Task.CompletedTask;
+            }
+
+            if (!ColumnExists(PageMetric.TableName, "PageData"))
+            {
+                Logger.LogDebug("The column PageData does not exist, skipping");
+                return Task.CompletedTask;
+            }
+
+            // For SQL Server: change NTEXT to NVARCHAR(MAX)
+            Alter.Table(PageMetric.TableName)
+                .AlterColumn("PageData")
+                .AsString(int.MaxValue)
+                .Nullable()
+                .Do();
+
+            Logger.LogDebug("Changed PageData column from NTEXT to NVARCHAR(MAX)");
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Umbraco.Community.Sustainability/Models/PageCoverageData.cs
+++ b/src/Umbraco.Community.Sustainability/Models/PageCoverageData.cs
@@ -1,0 +1,18 @@
+namespace Umbraco.Community.Sustainability.Models
+{
+    /// <summary>
+    /// Data about sustainability test coverage across the site.
+    /// </summary>
+    public class PageCoverageData
+    {
+        /// <summary>
+        /// Number of pages that have been tested for sustainability.
+        /// </summary>
+        public int TestedPageCount { get; set; }
+
+        /// <summary>
+        /// Number of tested pages whose metrics are older than the configured threshold.
+        /// </summary>
+        public int StalePageCount { get; set; }
+    }
+}

--- a/src/Umbraco.Community.Sustainability/Models/SustainabilityHealthCheckSettings.cs
+++ b/src/Umbraco.Community.Sustainability/Models/SustainabilityHealthCheckSettings.cs
@@ -1,0 +1,14 @@
+namespace Umbraco.Community.Sustainability.Models
+{
+    /// <summary>
+    /// Configuration settings for sustainability health checks.
+    /// </summary>
+    public class SustainabilityHealthCheckSettings
+    {
+        /// <summary>
+        /// Number of days after which page metrics are considered stale.
+        /// Default: 30 days.
+        /// </summary>
+        public int StaleDays { get; set; } = 30;
+    }
+}

--- a/src/Umbraco.Community.Sustainability/Notifications/PageMetricsNotificationHandler.cs
+++ b/src/Umbraco.Community.Sustainability/Notifications/PageMetricsNotificationHandler.cs
@@ -11,7 +11,7 @@ using Umbraco.Community.Sustainability.Schemas;
 
 namespace Umbraco.Community.Sustainability.Notifications
 {
-    public class PageMetricsNotificationHandler : INotificationHandler<UmbracoApplicationStartingNotification>
+    public class PageMetricsNotificationHandler : INotificationAsyncHandler<UmbracoApplicationStartingNotification>
     {
         private readonly IMigrationPlanExecutor _migrationPlanExecutor;
         private readonly ICoreScopeProvider _coreScopeProvider;
@@ -33,7 +33,7 @@ namespace Umbraco.Community.Sustainability.Notifications
             _userGroupService = userGroupService;
         }
 
-        public async void Handle(UmbracoApplicationStartingNotification notification)
+        public async Task HandleAsync(UmbracoApplicationStartingNotification notification, CancellationToken cancellationToken)
         {
             if (_runtimeState.Level < RuntimeLevel.Run)
             {

--- a/src/Umbraco.Community.Sustainability/Notifications/PageMetricsNotificationHandler.cs
+++ b/src/Umbraco.Community.Sustainability/Notifications/PageMetricsNotificationHandler.cs
@@ -49,12 +49,13 @@ namespace Umbraco.Community.Sustainability.Notifications
             migrationPlan.From(string.Empty)
                 .To<AddPageMetricsTable>("pagemetrics-init")
                 .To<AddCarbonRating>("pagemetrics-carbonrating")
-                .To<ChangeNodeIdToNodeKey>("pagemetrics-nodeidtonodekey");
+                .To<ChangeNodeIdToNodeKey>("pagemetrics-nodeidtonodekey")
+                .To<ChangePageDataToNVarcharMax>("pagemetrics-pagedatatonvarcharmax");
 
             // Go and upgrade our site (Will check if it needs to do the work or not)
             // Based on the current/latest step
             var upgrader = new Upgrader(migrationPlan);
-            upgrader.Execute(
+            await upgrader.ExecuteAsync(
                 _migrationPlanExecutor,
                 _coreScopeProvider,
                 _keyValueService);

--- a/src/Umbraco.Community.Sustainability/Schemas/PageMetricSchema.cs
+++ b/src/Umbraco.Community.Sustainability/Schemas/PageMetricSchema.cs
@@ -41,7 +41,6 @@ namespace Umbraco.Community.Sustainability.Schemas
 
         [Column("PageData")]
         [NullSetting(NullSetting = NullSettings.Null)]
-        [SpecialDbType(SpecialDbTypes.NTEXT)]
         public string? PageData { get; set; }
 
         [Ignore]

--- a/src/Umbraco.Community.Sustainability/Services/PageMetricService.cs
+++ b/src/Umbraco.Community.Sustainability/Services/PageMetricService.cs
@@ -16,6 +16,12 @@ namespace Umbraco.Community.Sustainability.Services
 
     public class PageMetricService : IPageMetricService
     {
+        private sealed class LatestMetricByNode
+        {
+            public Guid NodeKey { get; set; }
+            public DateTime LatestRequestDate { get; set; }
+        }
+
         private readonly IScopeProvider _scopeProvider;
         private readonly IPublishedContentQuery _contentQuery;
 
@@ -86,24 +92,25 @@ namespace Umbraco.Community.Sustainability.Services
             using var scope = _scopeProvider.CreateScope();
             var staleDate = DateTime.UtcNow.AddDays(-staleDays);
 
-            // Count distinct tested pages
-            var testedCountSql = scope.SqlContext.Sql()
-                .Select("COUNT(DISTINCT NodeKey)")
-                .From("umbPageMetrics")
-                .Where("NodeKey IS NOT NULL");
-            var testedCount = await scope.Database.ExecuteScalarAsync<int>(testedCountSql);
+            var latestMetricsSql = scope.SqlContext.Sql()
+                .Select("NodeKey, MAX(RequestDate) AS LatestRequestDate")
+                .From(PageMetric.TableName)
+                .Where("NodeKey IS NOT NULL")
+                .GroupBy("NodeKey");
 
-            // Count pages with stale metrics (all metrics older than threshold)
-            var staleCountSql = scope.SqlContext.Sql(@"
-                SELECT COUNT(*)
-                FROM (
-                    SELECT NodeKey
-                    FROM umbPageMetrics
-                    WHERE NodeKey IS NOT NULL
-                    GROUP BY NodeKey
-                    HAVING MAX(RequestDate) < @0
-                ) AS StalePages", staleDate);
-            var staleCount = await scope.Database.ExecuteScalarAsync<int>(staleCountSql);
+            var latestMetricsByNode = await scope.Database.FetchAsync<LatestMetricByNode>(latestMetricsSql);
+
+            var publishedMetrics = latestMetricsByNode
+                .Where(x => _contentQuery.Content(x.NodeKey) != null)
+                .ToList();
+
+            var testedCount = publishedMetrics.Count;
+            var staleCount = publishedMetrics.Count(x => x.LatestRequestDate < staleDate);
+
+            if (staleCount > testedCount)
+            {
+                staleCount = testedCount;
+            }
 
             scope.Complete();
 

--- a/src/Umbraco.Community.Sustainability/Services/PageMetricService.cs
+++ b/src/Umbraco.Community.Sustainability/Services/PageMetricService.cs
@@ -89,7 +89,8 @@ namespace Umbraco.Community.Sustainability.Services
             // Count distinct tested pages
             var testedCountSql = scope.SqlContext.Sql()
                 .Select("COUNT(DISTINCT NodeKey)")
-                .From("umbPageMetrics");
+                .From("umbPageMetrics")
+                .Where("NodeKey IS NOT NULL");
             var testedCount = await scope.Database.ExecuteScalarAsync<int>(testedCountSql);
 
             // Count pages with stale metrics (all metrics older than threshold)
@@ -98,6 +99,7 @@ namespace Umbraco.Community.Sustainability.Services
                 FROM (
                     SELECT NodeKey
                     FROM umbPageMetrics
+                    WHERE NodeKey IS NOT NULL
                     GROUP BY NodeKey
                     HAVING MAX(RequestDate) < @0
                 ) AS StalePages", staleDate);

--- a/src/Umbraco.Community.Sustainability/Services/PageMetricService.cs
+++ b/src/Umbraco.Community.Sustainability/Services/PageMetricService.cs
@@ -7,10 +7,11 @@ namespace Umbraco.Community.Sustainability.Services
 {
     public interface IPageMetricService
     {
-        Task<IEnumerable<PageMetric>> GetOverviewMetrics();
-        Task<AveragePageMetrics> GetAverageMetrics();
-        Task<IEnumerable<PageMetric>> GetPageMetrics(Guid pageKey);
-        Task AddPageMetric(PageMetric pageMetric);
+        public Task<IEnumerable<PageMetric>> GetOverviewMetrics();
+        public Task<AveragePageMetrics> GetAverageMetrics();
+        public Task<IEnumerable<PageMetric>> GetPageMetrics(Guid pageKey);
+        public Task AddPageMetric(PageMetric pageMetric);
+        public Task<PageCoverageData> GetPageCoverageData(int staleDays);
     }
 
     public class PageMetricService : IPageMetricService
@@ -36,8 +37,11 @@ namespace Umbraco.Community.Sustainability.Services
 
             foreach (var result in queryResults)
             {
-                var node = _contentQuery.Content(result.NodeKey);
-                result.NodeName = node?.Name;
+                if (result.NodeKey != null)
+                {
+                    var node = _contentQuery.Content(result.NodeKey);
+                    result.NodeName = node?.Name;
+                }
             }
 
             scope.Complete();
@@ -75,6 +79,37 @@ namespace Umbraco.Community.Sustainability.Services
             using var scope = _scopeProvider.CreateScope();
             await scope.Database.InsertAsync(pageMetric);
             scope.Complete();
+        }
+
+        public async Task<PageCoverageData> GetPageCoverageData(int staleDays)
+        {
+            using var scope = _scopeProvider.CreateScope();
+            var staleDate = DateTime.UtcNow.AddDays(-staleDays);
+
+            // Count distinct tested pages
+            var testedCountSql = scope.SqlContext.Sql()
+                .Select("COUNT(DISTINCT NodeKey)")
+                .From("umbPageMetrics");
+            var testedCount = await scope.Database.ExecuteScalarAsync<int>(testedCountSql);
+
+            // Count pages with stale metrics (all metrics older than threshold)
+            var staleCountSql = scope.SqlContext.Sql(@"
+                SELECT COUNT(*)
+                FROM (
+                    SELECT NodeKey
+                    FROM umbPageMetrics
+                    GROUP BY NodeKey
+                    HAVING MAX(RequestDate) < @0
+                ) AS StalePages", staleDate);
+            var staleCount = await scope.Database.ExecuteScalarAsync<int>(staleCountSql);
+
+            scope.Complete();
+
+            return new PageCoverageData
+            {
+                TestedPageCount = testedCount,
+                StalePageCount = staleCount
+            };
         }
     }
 }

--- a/src/Umbraco.Community.Sustainability/SustainabilityComposer.cs
+++ b/src/Umbraco.Community.Sustainability/SustainabilityComposer.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Composing;
@@ -50,9 +51,13 @@ namespace Umbraco.Community.Sustainability
                 builder.Config.GetSection("Sustainability:HealthChecks"));
 
             // Named HTTP client for Green Web Foundation API
+            var assemblyVersion = typeof(SustainabilityComposer).Assembly
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+                .InformationalVersion ?? "unknown";
+            var userAgent = $"Umbraco.Community.Sustainability/{assemblyVersion}";
+
             builder.Services.AddHttpClient("GreenWebFoundation", c =>
-                c.DefaultRequestHeaders.UserAgent.ParseAdd(
-                    "Umbraco.Community.Sustainability/5.0"));
+                c.DefaultRequestHeaders.UserAgent.ParseAdd(userAgent));
 
             builder.Services.ConfigureOptions<ConfigureSwaggerGenOptions>();
 

--- a/src/Umbraco.Community.Sustainability/SustainabilityComposer.cs
+++ b/src/Umbraco.Community.Sustainability/SustainabilityComposer.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Community.Sustainability
                 throw new Exception($"Playwright exited with code {exitCode}");
             }
 
-            builder.AddNotificationHandler<UmbracoApplicationStartingNotification, PageMetricsNotificationHandler>();
+            builder.AddNotificationAsyncHandler<UmbracoApplicationStartingNotification, PageMetricsNotificationHandler>();
 
             builder.Services.AddScoped<IPageMetricService, PageMetricService>();
             builder.Services.AddSingleton<ISustainabilityService, SustainabilityService>();

--- a/src/Umbraco.Community.Sustainability/SustainabilityComposer.cs
+++ b/src/Umbraco.Community.Sustainability/SustainabilityComposer.cs
@@ -45,6 +45,15 @@ namespace Umbraco.Community.Sustainability
             builder.Services.AddScoped<IPageMetricService, PageMetricService>();
             builder.Services.AddSingleton<ISustainabilityService, SustainabilityService>();
 
+            // Health check configuration
+            builder.Services.Configure<Models.SustainabilityHealthCheckSettings>(
+                builder.Config.GetSection("Sustainability:HealthChecks"));
+
+            // Named HTTP client for Green Web Foundation API
+            builder.Services.AddHttpClient("GreenWebFoundation", c =>
+                c.DefaultRequestHeaders.UserAgent.ParseAdd(
+                    "Umbraco.Community.Sustainability/5.0"));
+
             builder.Services.ConfigureOptions<ConfigureSwaggerGenOptions>();
 
             builder.Services.Configure<UmbracoPipelineOptions>(options =>


### PR DESCRIPTION
## Summary

Introduces three Umbraco health checks to monitor website sustainability metrics:

- **Page Coverage Health Check:** Reports the percentage of published pages that have been tested for sustainability. Displays warnings when metrics become stale (configurable threshold, default 30 days). Helps identify untested content and encourages regular monitoring.

- **Carbon Rating Health Check:** Evaluates the site's overall carbon footprint based on average page metrics (A+ to F rating). Provides actionable feedback when ratings fall below expectations. Uses consistent rating thresholds across the package.

- **Green Hosting Health Check:** Verifies if the website is hosted on green infrastructure using The Green Web Foundation API. Checks the current hostname from the application configuration.

Health checks can be configured via `appsettings.json` under `Sustainability:HealthChecks` section. The Page Coverage health check supports a configurable `StaleDays` threshold (default: 30 days) to determine when metrics are considered stale.

## Files changed

- **New:** `HealthChecks/CarbonRatingHealthCheck.cs`, `HealthChecks/GreenHostingHealthCheck.cs`, `HealthChecks/PageCoverageHealthCheck.cs`
- **New:** `Helpers/CarbonRatingHelper.cs` (shared rating calculation logic)
- **New:** `Models/PageCoverageData.cs`, `Models/SustainabilityHealthCheckSettings.cs`
- **New:** `Migrations/04_ChangePageDataToNVarcharMax.cs` (SQLite-compatible migration)
- **Modified:** `Services/PageMetricService.cs` (added `GetPageCoverageData` method)
- **Modified:** `SustainabilityComposer.cs` (health check configuration and HTTP client setup)