### PR TITLE
Refactor migrations to use AsyncMigrationBase

### DIFF
--- a/src/Umbraco.Community.Sustainability/Migrations/01_AddPageMetricsTable.cs
+++ b/src/Umbraco.Community.Sustainability/Migrations/01_AddPageMetricsTable.cs
@@ -4,13 +4,13 @@ using Umbraco.Community.Sustainability.Schemas;
 
 namespace Umbraco.Community.Sustainability.Migrations
 {
-    public class AddPageMetricsTable : MigrationBase
+    public class AddPageMetricsTable : AsyncMigrationBase
     {
         public AddPageMetricsTable(IMigrationContext context) : base(context)
         {
         }
 
-        protected override void Migrate()
+        protected override Task MigrateAsync()
         {
             Logger.LogDebug("Running migration {MigrationStep}", "AddPageMetricsTable");
 
@@ -22,6 +22,8 @@ namespace Umbraco.Community.Sustainability.Migrations
             {
                 Logger.LogDebug("The database table {DbTable} already exists, skipping", PageMetric.TableName);
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Umbraco.Community.Sustainability/Migrations/02_AddCarbonRating.cs
+++ b/src/Umbraco.Community.Sustainability/Migrations/02_AddCarbonRating.cs
@@ -4,13 +4,13 @@ using Umbraco.Community.Sustainability.Schemas;
 
 namespace Umbraco.Community.Sustainability.Migrations
 {
-    public class AddCarbonRating : MigrationBase
+    public class AddCarbonRating : AsyncMigrationBase
     {
         public AddCarbonRating(IMigrationContext context) : base(context)
         {
         }
 
-        protected override void Migrate()
+        protected override Task MigrateAsync()
         {
             Logger.LogDebug("Running migration {MigrationStep}", "AddCarbonRating");
 
@@ -22,6 +22,8 @@ namespace Umbraco.Community.Sustainability.Migrations
             {
                 Logger.LogDebug("The column CarbonRating already exists, skipping");
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Umbraco.Community.Sustainability/Migrations/03_ChangeNodeIdToKey.cs
+++ b/src/Umbraco.Community.Sustainability/Migrations/03_ChangeNodeIdToKey.cs
@@ -4,13 +4,13 @@ using Umbraco.Community.Sustainability.Schemas;
 
 namespace Umbraco.Community.Sustainability.Migrations
 {
-    public class ChangeNodeIdToNodeKey : MigrationBase
+    public class ChangeNodeIdToNodeKey : AsyncMigrationBase
     {
         public ChangeNodeIdToNodeKey(IMigrationContext context) : base(context)
         {
         }
 
-        protected override void Migrate()
+        protected override Task MigrateAsync()
         {
             Logger.LogDebug("Running migration {MigrationStep}", "ChangeNodeIdToNodeKey");
 
@@ -19,8 +19,8 @@ namespace Umbraco.Community.Sustainability.Migrations
                 Alter.Table(PageMetric.TableName).AddColumn("NodeKey").AsGuid().Nullable().Do();
 
                 Database.Execute($@"UPDATE {PageMetric.TableName} SET NodeKey = {Cms.Core.Constants.DatabaseSchema.Tables.Node}.uniqueId
-FROM {Cms.Core.Constants.DatabaseSchema.Tables.Node}
-INNER JOIN {PageMetric.TableName} ON {Cms.Core.Constants.DatabaseSchema.Tables.Node}.id = {PageMetric.TableName}.NodeId");
+                    FROM {Cms.Core.Constants.DatabaseSchema.Tables.Node}
+                    INNER JOIN {PageMetric.TableName} ON {Cms.Core.Constants.DatabaseSchema.Tables.Node}.id = {PageMetric.TableName}.NodeId");
 
                 Delete.Column("NodeId").FromTable(PageMetric.TableName).Do();
             }
@@ -28,6 +28,8 @@ INNER JOIN {PageMetric.TableName} ON {Cms.Core.Constants.DatabaseSchema.Tables.N
             {
                 Logger.LogDebug("The column NodeKey already exists, skipping");
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Umbraco.Community.Sustainability/Schemas/PageMetricSchema.cs
+++ b/src/Umbraco.Community.Sustainability/Schemas/PageMetricSchema.cs
@@ -41,7 +41,6 @@ namespace Umbraco.Community.Sustainability.Schemas
 
         [Column("PageData")]
         [NullSetting(NullSetting = NullSettings.Null)]
-        [SpecialDbType(SpecialDbTypes.NTEXT)]
         public string? PageData { get; set; }
 
         [Ignore]

--- a/src/Umbraco.Community.Sustainability/Schemas/PageMetricSchema.cs
+++ b/src/Umbraco.Community.Sustainability/Schemas/PageMetricSchema.cs
@@ -41,6 +41,7 @@ namespace Umbraco.Community.Sustainability.Schemas
 
         [Column("PageData")]
         [NullSetting(NullSetting = NullSettings.Null)]
+        [SpecialDbType(SpecialDbTypes.NTEXT)]
         public string? PageData { get; set; }
 
         [Ignore]


### PR DESCRIPTION
## Summary

Updates all existing migrations to use `AsyncMigrationBase` instead of the deprecated `MigrationBase` class, aligning with Umbraco CMS v17+ conventions.

- **Migration 01-03:** Converted from `MigrationBase` to `AsyncMigrationBase` with `MigrateAsync()` returning `Task`

This refactoring follows Umbraco CMS patterns where `MigrationBase` is marked obsolete and scheduled for removal in Umbraco 18, ensuring the package stays compatible with future Umbraco versions.

## Files changed

- **Modified:** `Migrations/01_AddPageMetricsTable.cs` (MigrationBase → AsyncMigrationBase)
- **Modified:** `Migrations/02_AddCarbonRating.cs` (MigrationBase → AsyncMigrationBase)  
- **Modified:** `Migrations/03_ChangeNodeIdToKey.cs` (MigrationBase → AsyncMigrationBase)

## Technical notes

- All migrations now return `Task.CompletedTask` since they perform synchronous database operations
- The async pattern prepares for future async database operations if needed
- No functional changes to migration behavior - purely structural refactoring

## Test plan

- [ ] Verify migrations still run successfully on a fresh install
- [ ] Confirm existing installations with migrations already applied are not affected
- [ ] Check that migration plan executes correctly through all steps (01 → 02 → 03)
- [ ] Test on both SQL Server and SQLite databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)